### PR TITLE
Support OAI-PMH explicit namespace

### DIFF
--- a/models/OaipmhHarvester/Request.php
+++ b/models/OaipmhHarvester/Request.php
@@ -176,6 +176,13 @@ class OaipmhHarvester_Request
         if ($response->isSuccessful() && !$response->isRedirect()) {
             libxml_use_internal_errors(true);
             $iter = simplexml_load_string($response->getBody());
+            if ($iter !== false) {
+                $ns = $iter->getNamespaces();
+                if (array_key_exists("oai", $ns)) {
+                    $iter = simplexml_load_string($response->getBody(),
+                            "SimpleXMLElement", 0, "oai", true);
+                }
+            }
             if ($iter === false) {
                 $errors = array();
                 foreach(libxml_get_errors() as $error) {


### PR DESCRIPTION
Thanks for a great harvesting plugin.

I was trying to harvest metadata (in DC) from a Geonode which uses pycsw to support OAIPMH. pycsw uses an explicit namespace in the response XML for "oai", whereas the plugin expects the default namespace.

I put a check for an explicit namespace in Request.php to re-parse the XML if it is present. The change tested OK with Geonode (explicit oai namespace) and a Geonetwork (default namespace).

I hope this is helpful.