### PR TITLE
Specific process

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,3 +11,40 @@ function oaipmh_harvester_config($key, $default = null)
         return null;
     }
 }
+
+/**
+ * Get the available OAI-PMH to Omeka maps, which should correspond to
+ * OAI-PMH metadata formats.
+ * Derived heavily from OaiPmhRepository's getFormats().
+ *
+ * @internal This list is needed in OaipmhHarvester_IndexController(),
+ * OaipmhHarvester_Harvest_Abstract() and OaipmhHarvester_Harvest().
+ *
+ * @return array
+ */
+function oaipmh_harvester_get_maps()
+{
+    $dir = new DirectoryIterator(OAIPMH_HARVESTER_MAPS_DIRECTORY);
+    $maps = array();
+    foreach ($dir as $dirEntry) {
+        if ($dirEntry->isFile() && !$dirEntry->isDot()) {
+            $filename = $dirEntry->getFilename();
+            $pathname = $dirEntry->getPathname();
+            if (preg_match('/^(.+)\.php$/', $filename, $match)
+                && $match[1] != 'Abstract'
+            ) {
+                // Get and set only the name of the file minus the extension.
+                require_once($pathname);
+                $class = "OaipmhHarvester_Harvest_${match[1]}";
+                $metadataSchema = constant("$class::METADATA_SCHEMA");
+                $metadataPrefix = constant("$class::METADATA_PREFIX");
+                $maps[$metadataPrefix] = array(
+                    'class' => $class,
+                    'schema' => $metadataSchema,
+                );
+            }
+        }
+    }
+
+    return apply_filters('oai_pmh_harvester_maps', $maps);
+}

--- a/models/OaipmhHarvester/Harvest.php
+++ b/models/OaipmhHarvester/Harvest.php
@@ -119,11 +119,7 @@ class OaipmhHarvester_Harvest extends Omeka_Record_AbstractRecord
         $validators = array(
             'base_url' => new Omeka_Validate_Uri(),
             'metadata_prefix' => new Zend_Validate_InArray(
-                array(
-                    'oai_dc',
-                    'cdwalite',
-                    'mets',
-                )
+                array_keys(oaipmh_harvester_get_maps())
             ),
         );
         foreach ($validators as $column => $validator) {

--- a/models/OaipmhHarvester/Harvest/Abstract.php
+++ b/models/OaipmhHarvester/Harvest/Abstract.php
@@ -174,22 +174,48 @@ abstract class OaipmhHarvester_Harvest_Abstract
         
         // Record has already been harvested
         if ($existingRecord) {
-            // If datestamp has changed, update the record, otherwise ignore.
-            if($existingRecord->datestamp != $record->header->datestamp) {
-                $this->_updateItem($existingRecord,
-                                  $harvestedRecord['elementTexts'],
-                                  $harvestedRecord['fileMetadata']);
+            // If datestamp has changed, update the record.
+            if ($existingRecord->datestamp != $record->header->datestamp) {
+                $item = $this->_updateItem(
+                    $existingRecord,
+                    $harvestedRecord['elementTexts'],
+                    $harvestedRecord['fileMetadata']);
+                $performed = 'updated';
             }
-            release_object($existingRecord);
+            // Ignore the update.
+            else {
+                $item = $existingRecord;
+                $performed = 'skipped';
+            }
         } else {
-            $this->_insertItem(
+            $item = $this->_insertItem(
                 $harvestedRecord['itemMetadata'],
                 $harvestedRecord['elementTexts'],
                 $harvestedRecord['fileMetadata']
             );
+            $performed = 'inserted';
         }
+
+        $this->_harvestRecordSpecific($item, $harvestedRecord, $performed);
+
+        // Release the Item object from memory.
+        release_object($item);
     }
-    
+
+    /**
+     * Ingest specific data, specialy for plugins that don't use elements.
+     *
+     * @internal A method is used, not a hook, because it depends of mapping.
+     *
+     * @param Record $record
+     * @param array $harvestedRecord
+     * @param string $performed Can be "inserted", "updated" or "skipped".
+     * @return void
+     */
+    protected function _harvestRecordSpecific($record, $harvestedRecord, $performed)
+    {
+    }
+
     /**
      * Return whether the record is deleted
      * 
@@ -315,7 +341,7 @@ abstract class OaipmhHarvester_Harvest_Abstract
      * @param mixed $metadata Item metadata
      * @param mixed $elementTexts The item's element texts
      * @param mixed $fileMetadata The item's file metadata
-     * @return true
+     * @return Item The inserted item.
      */
     final protected function _insertItem(
         $metadata = array(), 
@@ -363,11 +389,8 @@ abstract class OaipmhHarvester_Harvest_Abstract
                 release_object($fileObject);
             }
         }
-        
-        // Release the Item object from memory.
-        release_object($item);
-        
-        return true;
+
+        return $item;
     }
     
     /**
@@ -383,7 +406,7 @@ abstract class OaipmhHarvester_Harvest_Abstract
      * @param OaipmhHarvester_Record $itemId ID of item to update
      * @param mixed $elementTexts The item's element texts
      * @param mixed $fileMetadata The item's file metadata
-     * @return true
+     * @return Item The updated item.
      */
     final protected function _updateItem(
         $record, 
@@ -401,10 +424,7 @@ abstract class OaipmhHarvester_Harvest_Abstract
         // Update the datestamp stored in the database for this record.
         $this->_updateRecord($record);
 
-        // Release the Item object from memory.
-        release_object($item);
-        
-        return true;
+        return $item;
     }
     
     /**

--- a/models/OaipmhHarvester/Harvest/Abstract.php
+++ b/models/OaipmhHarvester/Harvest/Abstract.php
@@ -524,9 +524,9 @@ abstract class OaipmhHarvester_Harvest_Abstract
 
     public static function factory($harvest)
     {
-        $classSuffix = Inflector::camelize($harvest->metadata_prefix);
-        $class = 'OaipmhHarvester_Harvest_' . $classSuffix;
-        require_once OAIPMH_HARVESTER_MAPS_DIRECTORY . "/$classSuffix.php";
+        $maps = oaipmh_harvester_get_maps();
+        // The class is autoloaded.
+        $class = $maps[$harvest->metadata_prefix]['class'];
 
         // Set the harvest object.
         $harvester = new $class($harvest);


### PR DESCRIPTION
Hi,

All metadata are not ingestable via the harvester. So this patch allows to do a specific process after the standard harvest. This is useful with there are other maps (see https://github.com/omeka/plugin-OaipmhHarvester/pull/20).

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management