### PR TITLE
Handle empty resumptionToken on harvestRecords

### DIFF
--- a/models/OaipmhHarvester/Harvest/Abstract.php
+++ b/models/OaipmhHarvester/Harvest/Abstract.php
@@ -148,7 +148,7 @@ abstract class OaipmhHarvester_Harvest_Abstract
         }
         
         $resumptionToken = true;
-        if (isset($response['resumptionToken'])) {
+        if (isset($response['resumptionToken']) && strlen($response['resumptionToken']) > 0) {
             $resumptionToken = $response['resumptionToken'];
             $this->_addStatusMessage("Received resumption token: $resumptionToken");
         } else {


### PR DESCRIPTION
As stated on OAI/PMH v2 : 
> the response containing the incomplete list that completes the list must include an empty resumptionToken element;

So we should have an empty resumptionToken at then end of the last ListRecords which shouldn't be treated as a resumptionToken.

Without this fix, some OAI/PMH server generate a sort of inifite loop on `ListRecords` because it believe that it should continue to harvest.

Note : The fix could also be in a way xml response is converted, you could for exemple use [LIBXML_NOBLANKS](https://www.php.net/manual/en/libxml.constants.php#constant.libxml-noblanks) for `simplexml_load_string` or avoid to set the token when parsing the response. I let it to omeka team to choose what is the best way to handle the case.